### PR TITLE
Changes to running a StimPlan at a specific timestamp

### DIFF
--- a/src/cl/util/util.py
+++ b/src/cl/util/util.py
@@ -216,3 +216,17 @@ def more_accurate_sleep(seconds):
     #     time.sleep(seconds - 0.1)
     while time.perf_counter() < end:
         pass
+
+def deprecated(replacement=None):
+    """ Decorator that marks a method as deprecated, and prints a warning on first use. """
+    def decorator(method):
+        def wrapper(*args, **kwargs):
+            if not hasattr(method, '_warned_deprecation'):
+                if replacement:
+                    print(f"{method.__name__} is deprecated, use {replacement} instead")
+                else:
+                    print(f"{method.__name__} is deprecated")
+                method._warned_deprecation = True
+            return method(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
Interface for running a StimPlan at a specific timestamp has changed:
- from: `StimPlan.run_at_timestamp(timestamp)`
- to: `StimPlan.run(at_timestamp=timestamp)`

`StimPlan.run_at_timestamp(timestamp)` has been deprecated and will be removed in a future version. Using this will show a deprecation warning.