### PR TITLE
Fix charge validation, bare excepts, and docstring error

### DIFF
--- a/src/cl/__init__.py
+++ b/src/cl/__init__.py
@@ -398,7 +398,7 @@ class StimDesign:
         for i, (duration_us, current_uA) in enumerate(zip(durations, currents)):
             # Total charge
             charge_pC = current_uA * duration_us
-            if charge_pC > self._PHASE_CHARGE_INJECTION_LIMIT_PC:
+            if abs(charge_pC) > self._PHASE_CHARGE_INJECTION_LIMIT_PC:
                 raise ValueError(
                     f"Charge injection of "
                     f"{duration_us} us x {current_uA} uA = {charge_pC / 1000} nC "

--- a/src/cl/analysis/_metrics/_criticality.py
+++ b/src/cl/analysis/_metrics/_criticality.py
@@ -241,7 +241,7 @@ def _analyse_criticality(
         time_lags_k              = branching_ratio_result["time_lags_k"]
         time_lags_slopes         = branching_ratio_result["slopes"]
         time_lags_fit_parameters = branching_ratio_result["optimal_fit_parameters"]
-    except:
+    except Exception:
         ...
 
     return AnalysisResultCriticality(

--- a/src/cl/analysis/_metrics/_functional_connectivity.py
+++ b/src/cl/analysis/_metrics/_functional_connectivity.py
@@ -81,7 +81,7 @@ def _analyse_functional_connectivity(
         result.graph_partition  = community_louvain.best_partition(graph, weight="weight") # dict {node: community_id}
         if len(set(result.graph_partition.values())) > 1:
             result.modularity_index = float(community_louvain.modularity(result.graph_partition, graph, weight="weight"))
-    except:
+    except Exception:
         ...
 
     # Betweenness centrality (weighted)

--- a/src/cl/analysis/_metrics/_information_entropy.py
+++ b/src/cl/analysis/_metrics/_information_entropy.py
@@ -11,7 +11,7 @@ def _analyse_information_entropy(
     log_base:       float | None = None,
     ) -> AnalysisResultInformationEntropy:
     """
-    See RecordingView.analyse_lempel_ziv_complexity()
+    See RecordingView.analyse_information_entropy()
     """
     sampling_frequency = recording._analysis_cache.metadata.sampling_frequency
     bin_size_frames    = max(1, int(round(bin_size_sec * sampling_frequency)))


### PR DESCRIPTION
## Summary

Three small fixes across the SDK:

**1. Charge injection validation now checks absolute value** (`src/cl/__init__.py`)

`StimDesign._validate` only checked `charge_pC > limit`, so a cathodic (negative current) phase could bypass the 3.0 nC safety limit. For example, `-3.0 uA × 1200 us = -3.6 nC` would pass the check despite exceeding the charge injection limit. Changed to `abs(charge_pC) > limit`.

**2. Bare `except:` replaced with `except Exception:`** (`_criticality.py`, `_functional_connectivity.py`)

Bare `except:` catches `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` in addition to regular exceptions. This can mask issues during long-running analysis and prevent users from interrupting stuck computations.

**3. Copy-paste docstring fix** (`_information_entropy.py`)

`_analyse_information_entropy` docstring referenced `analyse_lempel_ziv_complexity()` instead of `analyse_information_entropy()`.